### PR TITLE
fix: switch to failPlugin instead of failBuild

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const fetch = require('node-fetch');
 module.exports = {
   async onSuccess({
     utils: {
-      build: { failPlugin, failBuild },
+      build: { failPlugin },
     },
   }) {
     if (CONTEXT === 'production') {
@@ -45,7 +45,7 @@ module.exports = {
 
         console.log('PerfBeacon test submitted!');
       } catch (error) {
-        return failBuild('PerfBeacon test failed', { error });
+        return failPlugin('PerfBeacon test failed', { error });
       }
     }
   },


### PR DESCRIPTION
Hi @rozenmd, thank you for creating this plugin.

We're making a change to how `onSuccess` works.

**Current:**  `onSuccess` occurs after the build command is complete, but before any files are uploaded.
**Upcoming:** `onSuccess`  occurs after the site is deployed, live, and published to production (if applicable).

As a result `onSuccess` can no longer be used to fail the build, hence the change to `failPlugin`.

Since it seems this plugin triggers an async round of tests it would make sense to use `failPlugin` (if I'm not mistaken).